### PR TITLE
Update dependencies and project files

### DIFF
--- a/libs/garf_core/pyproject.toml
+++ b/libs/garf_core/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",

--- a/libs/garf_executors/garf_executors/__init__.py
+++ b/libs/garf_executors/garf_executors/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
   'ApiQueryExecutor',
 ]
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/libs/garf_executors/pyproject.toml
+++ b/libs/garf_executors/pyproject.toml
@@ -7,6 +7,7 @@ name = "garf-executors"
 dependencies = [
   "garf-core",
   "garf-io",
+  "pyyaml",
 ]
 authors = [
   {name = "Google Inc. (gTech gPS CSE team)", email = "no-reply@google.com"},
@@ -22,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",

--- a/libs/garf_io/garf_io/__init__.py
+++ b/libs/garf_io/garf_io/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '0.0.2'

--- a/libs/garf_io/pyproject.toml
+++ b/libs/garf_io/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garf-io"
-version = "0.0.2"
 dependencies = [
   'garf-core',
   'smart_open',
@@ -24,11 +23,16 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",
 ]
+dynamic=["version"]
+
+[tool.setuptools.dynamic]
+version = {attr = "garf_io.__version__"}
 
 [options.extras_require]
 test =  [


### PR DESCRIPTION
* Add missing pyyaml dependency for garf-executors
* Mention python 3.13 support
* Extract __version__ to an attribute in garf_core