### PR TITLE
[youtube-data-api] Update YouTubeDataApiClient and YouTubeDataApiReportFetcher

### DIFF
--- a/libs/garf_community/youtube/garf_youtube_data_api/garf_youtube_data_api/api_clients.py
+++ b/libs/garf_community/youtube/garf_youtube_data_api/garf_youtube_data_api/api_clients.py
@@ -18,10 +18,16 @@ import os
 from googleapiclient.discovery import build
 from typing_extensions import override
 
-from garf_core import api_clients, query_editor
+from garf_core import api_clients, exceptions, query_editor
+
+
+class YouTubeDataApiClientError(exceptions.GarfYouTubeDataApiError):
+  """API client specific exception."""
 
 
 class YouTubeDataApiClient(api_clients.BaseClient):
+  """Handles fetching data form YouTube Data API."""
+
   def __init__(
     self,
     api_key: str = os.getenv('GOOGLE_API_KEY'),
@@ -29,6 +35,11 @@ class YouTubeDataApiClient(api_clients.BaseClient):
     **kwargs: str,
   ) -> None:
     """Initializes YouTubeDataApiClient."""
+    if not api_key:
+      raise YouTubeDataApiClientError(
+        'api_key is not found. Either pass to YouTubeDataApiClient as api_key '
+        'parameter or expose as GOOGLE_API_KEY ENV varible'
+      )
     self.api_key = api_key
     self.api_version = api_version
     self.api_key

--- a/libs/garf_community/youtube/garf_youtube_data_api/garf_youtube_data_api/exceptions.py
+++ b/libs/garf_community/youtube/garf_youtube_data_api/garf_youtube_data_api/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Defines simplified imports."""
+"""Defines common library exceptions."""
 
-from __future__ import annotations
 
-from garf_youtube_data_api.api_clients import YouTubeDataApiClient
-from garf_youtube_data_api.report_fetcher import YouTubeDataApiReportFetcher
-
-__all__ = [
-  'YouTubeDataApiClient',
-  'YouTubeDataApiReportFetcher',
-]
-
-__version__ = '0.0.6'
+class GarfYouTubeDataApiError(Exception):
+  """Base class for all library exceptions."""

--- a/libs/garf_community/youtube/garf_youtube_data_api/garf_youtube_data_api/report_fetcher.py
+++ b/libs/garf_community/youtube/garf_youtube_data_api/garf_youtube_data_api/report_fetcher.py
@@ -23,6 +23,7 @@ from typing import Any, Final
 from typing_extensions import override
 
 from garf_core import parsers, report, report_fetcher
+from garf_youtube_data_api import query_editor
 from garf_youtube_data_api.api_clients import YouTubeDataApiClient
 
 ALLOWED_FILTERS: Final[set[str]] = (
@@ -54,10 +55,13 @@ class YouTubeDataApiReportFetcher(report_fetcher.ApiReportFetcher):
     self,
     api_client: YouTubeDataApiClient = YouTubeDataApiClient(),
     parser: parsers.BaseParser = parsers.NumericConverterDictParser,
+    query_spec: query_editor.YouTubeDataApiQuery = (
+      query_editor.YouTubeDataApiQuery
+    ),
     **kwargs: str,
   ) -> None:
     """Initializes YouTubeDataApiReportFetcher."""
-    super().__init__(api_client, parser, **kwargs)
+    super().__init__(api_client, parser, query_spec, **kwargs)
 
   @override
   def fetch(


### PR DESCRIPTION
* Raise exception when API key is not set or directly provided to YouTubeDataApiClient
* Pass YouTubeDataApiQuery to YouTubeDataApiReportFetcher to allow additional query customization
* Add common GarfYouTubeDataApiError in exceptions module
