### PR TITLE
[core] chore: ensure that Rest and FakeApiReportFetcher are conforming ApiReportFetcher interface

### DIFF
--- a/libs/garf_core/garf_core/__init__.py
+++ b/libs/garf_core/garf_core/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/libs/garf_core/garf_core/fetchers/rest.py
+++ b/libs/garf_core/garf_core/fetchers/rest.py
@@ -40,11 +40,12 @@ class RestApiReportFetcher(report_fetcher.ApiReportFetcher):
 
   def __init__(
     self,
-    endpoint: str,
+    api_client: api_clients.RestApiClient | None = None,
     parser: parsers.BaseParser = parsers.DictParser,
     query_specification_builder: query_editor.QuerySpecification = (
       query_editor.QuerySpecification
     ),
+    endpoint: str | None = None,
     **kwargs: str,
   ) -> None:
     """Instantiates RestApiReportFetcher.
@@ -54,5 +55,17 @@ class RestApiReportFetcher(report_fetcher.ApiReportFetcher):
       parser: Type of parser to convert API response.
       query_specification_builder: Class to perform query parsing.
     """
-    api_client = api_clients.RestApiClient(endpoint)
+    if not api_client and not endpoint:
+      raise report_fetcher.ApiReportFetcherError(
+        'Missing api_client or endpoint for the fetcher.'
+      )
+    if not api_client:
+      api_client = api_clients.RestApiClient(endpoint)
     super().__init__(api_client, parser, query_specification_builder, **kwargs)
+
+  @classmethod
+  def from_endpoint(cls, endpoint: str) -> RestApiReportFetcher:
+    """Initializes RestApiReportFetcher: from an API endpoint."""
+    return RestApiReportFetcher(
+      api_client=api_clients.RestApiClient(endpoint=endpoint)
+    )

--- a/libs/garf_core/tests/unit/fetchers/test_fake.py
+++ b/libs/garf_core/tests/unit/fetchers/test_fake.py
@@ -27,7 +27,7 @@ class TestFakeApiReportFetcher:
   ]
 
   def test_fetch_from_data_returns_correct_result(self):
-    fetcher = FakeApiReportFetcher(data=self.data)
+    fetcher = FakeApiReportFetcher.from_data(self.data)
 
     result = fetcher.fetch(
       'SELECT field1.subfield AS column_name FROM resource_name'


### PR DESCRIPTION
* Always accept api_client as a first argument of __init__
* Add class methods for initializing clients (FakeApiReportFetcher.from_data and RestApiClient.from_endpoint)