### PR TITLE
[executors] feat: unify bq and sqldb executors

### DIFF
--- a/libs/garf_executors/garf_executors/__init__.py
+++ b/libs/garf_executors/garf_executors/__init__.py
@@ -15,8 +15,31 @@
 
 from __future__ import annotations
 
+from garf_executors import bq_executor, exceptions, sql_executor
 from garf_executors.api_executor import ApiExecutionContext, ApiQueryExecutor
 from garf_executors.fetchers import FETCHERS
+
+
+def setup_executor(source: str, fetcher_parameters: dict[str, str]):
+  """Initializes executors based on a source and parameters."""
+  if source not in ('bq', 'sqldb') and not (
+    concrete_api_fetcher := FETCHERS.get(source)
+  ):
+    raise exceptions.GarfExecutorError(f'Source {source} is not available.')
+  if source == 'bq':
+    query_executor = bq_executor.BigQueryExecutor(**fetcher_parameters)
+  elif source == 'sqldb':
+    query_executor = (
+      sql_executor.SqlAlchemyQueryExecutor.from_connection_string(
+        fetcher_parameters.get('connection_string')
+      )
+    )
+  else:
+    query_executor = ApiQueryExecutor(
+      concrete_api_fetcher(**fetcher_parameters)
+    )
+  return query_executor
+
 
 __all__ = [
   'FETCHERS',

--- a/libs/garf_executors/garf_executors/api_executor.py
+++ b/libs/garf_executors/garf_executors/api_executor.py
@@ -22,45 +22,16 @@ from __future__ import annotations
 
 import logging
 
-import pydantic
-
-from garf_core import query_editor, report_fetcher
-from garf_executors import exceptions
-from garf_io import writer
-from garf_io.writers import abs_writer
+from garf_core import report_fetcher
+from garf_executors import exceptions, execution_context
 
 logger = logging.getLogger(__name__)
 
 
-class ApiExecutionContext(pydantic.BaseModel):
-  """Common context for executing one or more queries.
+class ApiExecutionContext(execution_context.ExecutionContext):
+  """Common context for executing one or more queries."""
 
-  Attributes:
-    query_parameters: Parameters to dynamically change query text.
-    fetcher_parameters: Parameters to specify fetching setup.
-    writer: Type of writer to use.
-    writer_parameters: Optional parameters to setup writer.
-  """
-
-  query_parameters: query_editor.GarfQueryParameters | None = None
-  fetcher_parameters: dict[str, str] | None = None
   writer: str = 'console'
-  writer_parameters: dict[str, str] | None = None
-
-  def model_post_init(self, __context__) -> None:
-    if self.fetcher_parameters is None:
-      self.fetcher_parameters = {}
-    if self.writer_parameters is None:
-      self.writer_parameters = {}
-
-  @property
-  def writer_client(self) -> abs_writer.AbsWriter:
-    writer_client = writer.create_writer(self.writer, **self.writer_parameters)
-    if self.writer == 'bq':
-      _ = writer_client.create_or_get_dataset()
-    if self.writer == 'sheet':
-      writer_client.init_client()
-    return writer_client
 
 
 class ApiQueryExecutor:
@@ -79,15 +50,22 @@ class ApiQueryExecutor:
     self.fetcher = fetcher
 
   async def aexecute(
-    self, query: str, context: ApiExecutionContext, **kwargs: str
+    self,
+    query: str,
+    title: str,
+    context: ApiExecutionContext,
   ) -> str:
-    """Reads query, extract results and stores them in a specified location.
+    """Performs query execution asynchronously.
 
     Args:
       query: Location of the query.
+      title: Name of the query.
       context: Query execution context.
+
+    Returns:
+      Result of writing the report.
     """
-    await self.execute(query, context, **kwargs)
+    return await self.execute(query, context, title, context)
 
   def execute(
     self,

--- a/libs/garf_executors/garf_executors/entrypoints/server.py
+++ b/libs/garf_executors/garf_executors/entrypoints/server.py
@@ -22,6 +22,7 @@ import uvicorn
 
 import garf_executors
 from garf_executors import exceptions
+from garf_executors.entrypoints import utils
 from garf_io import reader
 
 
@@ -72,28 +73,17 @@ router = fastapi.APIRouter(prefix='/api')
 
 @router.post('/execute')
 async def execute(request: ApiExecutorRequest) -> ApiExecutorResponse:
-  if not (concrete_api_fetcher := garf_executors.FETCHERS.get(request.source)):
-    raise exceptions.GarfExecutorError(
-      f'Source {request.source} is not available.'
-    )
-
-  query_executor = garf_executors.ApiQueryExecutor(
-    concrete_api_fetcher(**request.context.fetcher_parameters)
+  query_executor = garf_executors.setup_executor(
+    request.source, request.context.fetcher_parameters
   )
-
   result = query_executor.execute(request.query, request.title, request.context)
   return ApiExecutorResponse(results=[result])
 
 
 @router.post('/execute:batch')
 async def execute_batch(request: ApiExecutorRequest) -> ApiExecutorResponse:
-  if not (concrete_api_fetcher := garf_executors.FETCHERS.get(request.source)):
-    raise exceptions.GarfExecutorError(
-      f'Source {request.source} is not available.'
-    )
-
-  query_executor = garf_executors.ApiQueryExecutor(
-    concrete_api_fetcher(**request.context.fetcher_parameters)
+  query_executor = garf_executors.setup_executor(
+    request.source, request.context.fetcher_parameters
   )
   file_reader = reader.FileReader()
   results = []

--- a/libs/garf_executors/garf_executors/execution_context.py
+++ b/libs/garf_executors/garf_executors/execution_context.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=C0330, g-bad-import-order, g-multiple-import
+
+from __future__ import annotations
+
+import pydantic
+
+from garf_core import query_editor
+from garf_io import writer
+from garf_io.writers import abs_writer
+
+
+class ExecutionContext(pydantic.BaseModel):
+  """Common context for executing one or more queries.
+
+  Attributes:
+    query_parameters: Parameters to dynamically change query text.
+    fetcher_parameters: Parameters to specify fetching setup.
+    writer: Type of writer to use.
+    writer_parameters: Optional parameters to setup writer.
+  """
+
+  query_parameters: query_editor.GarfQueryParameters | None = pydantic.Field(
+    default_factory=dict
+  )
+  fetcher_parameters: dict[str, str] | None = pydantic.Field(
+    default_factory=dict
+  )
+  writer: str | None = None
+  writer_parameters: dict[str, str] | None = pydantic.Field(
+    default_factory=dict
+  )
+
+  def model_post_init(self, __context__) -> None:
+    if self.fetcher_parameters is None:
+      self.fetcher_parameters = {}
+    if self.writer_parameters is None:
+      self.writer_parameters = {}
+
+  @property
+  def writer_client(self) -> abs_writer.AbsWriter:
+    writer_client = writer.create_writer(self.writer, **self.writer_parameters)
+    if self.writer == 'bq':
+      _ = writer_client.create_or_get_dataset()
+    if self.writer == 'sheet':
+      writer_client.init_client()
+    return writer_client

--- a/libs/garf_executors/tests/unit/test_sql_executor.py
+++ b/libs/garf_executors/tests/unit/test_sql_executor.py
@@ -14,10 +14,10 @@
 
 from __future__ import annotations
 
-import pandas as pd
 import pytest
 import sqlalchemy
 
+from garf_core import report
 from garf_executors import sql_executor
 
 
@@ -32,7 +32,7 @@ class TestSqlAlchemyQueryExecutor:
 
   def test_execute_returns_data_saved_to_db(self, executor, engine):
     query = 'CREATE TABLE test AS SELECT 1 AS one;'
-    executor.execute(script_name='test', query_text=query)
+    executor.execute(title='test', query=query)
 
     with engine.connect() as connection:
       result = connection.execute(sqlalchemy.text('select one from test'))
@@ -41,6 +41,6 @@ class TestSqlAlchemyQueryExecutor:
 
   def test_execute_returns_data_to_caller(self, executor):
     query = 'SELECT 1 AS one;'
-    expected_result = pd.DataFrame(data=[[1]], columns=['one'])
-    result = executor.execute(script_name='test', query_text=query)
-    assert result.equals(expected_result)
+    expected_result = report.GarfReport(results=[[1]], column_names=['one'])
+    result = executor.execute(title='test', query=query)
+    assert result == expected_result


### PR DESCRIPTION
* Add support for bq and sqldb executors in CLI and server
* Add `create_executor` package level function.
* BQ and SqlAlchemy executors returns GarfReport instead of DataFrame; If writer is provided the results are written to specified writer destination, otherwise results of execution are returned back to caller.
* Add ExecutionContext class for all executors that contains writer, query_, fetcher_ and writer_parameters. ApiExecutionContext contains predefined 'console' writer.