### PR TITLE
[core] fix: parse dot separated keys first

### DIFF
--- a/libs/core/garf_core/__init__.py
+++ b/libs/core/garf_core/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/libs/core/garf_core/parsers.py
+++ b/libs/core/garf_core/parsers.py
@@ -83,6 +83,8 @@ class DictParser(BaseParser):
 
   def get_nested_field(self, dictionary: dict[str, Any], key: str):
     """Returns nested fields from a dictionary."""
+    if result := dictionary.get(key):
+      return result
     key = key.split('.')
     try:
       return functools.reduce(operator.getitem, key, dictionary)
@@ -101,6 +103,9 @@ class NumericConverterDictParser(DictParser):
         with contextlib.suppress(ValueError):
           return type_(value)
       return value
+
+    if result := dictionary.get(key):
+      return convert_field(result)
 
     key = key.split('.')
     try:


### PR DESCRIPTION
If field in BaseQueryElements contains dots process them as is, if no key found, performn splitting and nest searching