### PR TITLE
[core] fix: define QueryParameters type with Union syntax

### DIFF
--- a/libs/core/garf_core/__init__.py
+++ b/libs/core/garf_core/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'

--- a/libs/core/garf_core/query_editor.py
+++ b/libs/core/garf_core/query_editor.py
@@ -20,7 +20,7 @@ import dataclasses
 import datetime
 import logging
 import re
-from typing import Generator
+from typing import Generator, Union
 
 import jinja2
 import pydantic
@@ -29,7 +29,7 @@ from typing_extensions import Self
 
 from garf_core import exceptions
 
-QueryParameters = dict[str, str | float | int]
+QueryParameters = dict[str, Union[str | float | int]]
 
 
 class GarfQueryParameters(pydantic.BaseModel):


### PR DESCRIPTION
In order to support python 3.8+