### PR TITLE
[dbm] fix: stop API response processing on half-empty lines

### DIFF
--- a/libs/community/google/bid-manager/examples/youtube_performance.sql
+++ b/libs/community/google/bid-manager/examples/youtube_performance.sql
@@ -1,0 +1,9 @@
+SELECT
+  date AS date,
+  youtube_ad_video_id AS media_url,
+  youtube_ad_video AS media_name,
+  metric_impressions AS impressions,
+  metric_clicks AS clicks
+FROM youtube
+WHERE advertiser = {advertiser_id}
+AND dataRange = LAST_30_DAYS

--- a/libs/community/google/bid-manager/garf_bid_manager/__init__.py
+++ b/libs/community/google/bid-manager/garf_bid_manager/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
   'BidManagerApiReportFetcher',
 ]
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
 logging.getLogger('google_auth_oauthlib.flow').setLevel(logging.ERROR)

--- a/libs/community/google/bid-manager/garf_bid_manager/api_clients.py
+++ b/libs/community/google/bid-manager/garf_bid_manager/api_clients.py
@@ -113,7 +113,10 @@ class BidManagerApiClient(api_clients.BaseClient):
     results = []
     for row in data[1:]:
       if row := row.strip():
-        result = dict(zip(request.fields, row.split(',')))
+        elements = row.split(',')
+        if not elements[0]:
+          break
+        result = dict(zip(request.fields, elements))
         results.append(result)
       else:
         break


### PR DESCRIPTION
When line with empty element appear it means that we're working on a summary line.