### PR TITLE
[exporters] feat: add support for macros and template in queries

### DIFF
--- a/libs/exporters/garf_exporter/__init__.py
+++ b/libs/exporters/garf_exporter/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
   'GarfExporter',
 ]
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/libs/exporters/garf_exporter/entrypoints/cli.py
+++ b/libs/exporters/garf_exporter/entrypoints/cli.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import datetime
-from typing import Literal
 
 import fastapi
 import prometheus_client
@@ -203,8 +202,11 @@ def main(
   request = exporter_service.GarfExporterRequest(
     source=source,
     source_parameters=cli_parameters.get('source'),
-    collectors_config=config,
-    macros=cli_parameters.get('macro'),
+    collectors_config=args.config,
+    query_parameters={
+      'macro': cli_parameters.get('macro', {}),
+      'template': cli_parameters.get('template', {}),
+    },
     runtime_options=runtime_options,
   )
   exporter.namespace = request.runtime_options.namespace

--- a/libs/exporters/tests/unit/test_exporter.py
+++ b/libs/exporters/tests/unit/test_exporter.py
@@ -23,7 +23,7 @@ from prometheus_client import samples
 class TestGaaarfExporter:
   @pytest.fixture
   def garf_exporter(self):
-    return GarfExporter()
+    return GarfExporter(namespace='test')
 
   @pytest.fixture
   def report(self):
@@ -65,23 +65,22 @@ class TestGaaarfExporter:
   def test_export_returns_correct_metric_name(self, garf_exporter, report):
     garf_exporter.export(report)
     metrics = list(garf_exporter.registry.collect())
-    assert 'googleads_clicks' in [metric.name for metric in metrics]
+    assert 'test_clicks' in [metric.name for metric in metrics]
 
-  def test_export_returns_correct_metric_name_with_suffix_and_namespace(
+  def test_export_returns_correct_metric_name_with_suffix(
     self, garf_exporter, report
   ):
-    namespace = 'ads'
     suffix = 'performance'
-    garf_exporter.export(report=report, namespace=namespace, suffix=suffix)
+    garf_exporter.export(report=report, suffix=suffix)
     metrics = list(garf_exporter.registry.collect())
-    assert f'{namespace}_{suffix}_clicks' in [metric.name for metric in metrics]
+    assert f'test_{suffix}_clicks' in [metric.name for metric in metrics]
 
   def test_export_returns_correct_virtual_metric_name(
     self, garf_exporter, report_with_virtual_column
   ):
     garf_exporter.export(report=report_with_virtual_column)
     metrics = list(garf_exporter.registry.collect())
-    assert 'googleads_info' in [metric.name for metric in metrics]
+    assert 'test_info' in [metric.name for metric in metrics]
 
   def test_export_returns_correct_metric_documentation(
     self, garf_exporter, report
@@ -94,7 +93,7 @@ class TestGaaarfExporter:
     garf_exporter.export(report)
     metrics = list(garf_exporter.registry.collect())
     for metric in metrics:
-      if metric.name == 'googleads_clicks':
+      if metric.name == 'test_clicks':
         assert len(metric.samples) == len(report.results)
 
   @pytest.mark.parametrize(
@@ -102,10 +101,10 @@ class TestGaaarfExporter:
     [
       [
         samples.Sample(
-          name='googleads_clicks', labels={'campaign_id': '1'}, value=10.0
+          name='test_clicks', labels={'campaign_id': '1'}, value=10.0
         ),
         samples.Sample(
-          name='googleads_clicks', labels={'campaign_id': '2'}, value=20.0
+          name='test_clicks', labels={'campaign_id': '2'}, value=20.0
         ),
       ]
     ],
@@ -116,5 +115,5 @@ class TestGaaarfExporter:
     garf_exporter.export(report)
     metrics = list(garf_exporter.registry.collect())
     for metric in metrics:
-      if metric.name == 'googleads_clicks':
+      if metric.name == 'test_clicks':
         assert metric.samples == expected_samples


### PR DESCRIPTION
* Add query_parameters property to GarfExporterRequest and propagate to fetch
* Rely on Exporter level namespace instead of setting custom one in export method
* Use garf namespace by default
* Update tests