### PR TITLE
[core] feat: improve handling empty response from API

### DIFF
--- a/libs/core/garf_core/__init__.py
+++ b/libs/core/garf_core/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
   'ApiReportFetcher',
 ]
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/libs/core/garf_core/api_clients.py
+++ b/libs/core/garf_core/api_clients.py
@@ -39,6 +39,9 @@ class GarfApiResponse(pydantic.BaseModel):
 
   results: list[ApiResponseRow]
 
+  def __bool__(self) -> bool:
+    return bool(self.results)
+
 
 class GarfApiError(exceptions.GarfError):
   """API specific exception."""

--- a/libs/core/garf_core/report.py
+++ b/libs/core/garf_core/report.py
@@ -403,6 +403,10 @@ class GarfReport:
     """
     if not isinstance(other, self.__class__):
       raise GarfReportError('Add operation is supported only for GarfReport')
+    if not other:
+      return self
+    if not self:
+      return other
     if self.column_names != other.column_names:
       raise GarfReportError('column_names should be the same in GarfReport')
     return GarfReport(
@@ -634,6 +638,9 @@ class GarfRow:
 
   def __repr__(self):
     return f'GarfRow(\n{self.to_dict()}\n)'
+
+  def __bool__(self) -> bool:
+    return bool(self.data)
 
 
 class GarfReportError(exceptions.GarfError):

--- a/libs/core/garf_core/report_fetcher.py
+++ b/libs/core/garf_core/report_fetcher.py
@@ -148,6 +148,9 @@ class ApiReportFetcher:
       return builtin_report(self, **kwargs)
 
     response = self.api_client.get_response(query, **kwargs)
+    if not response:
+      return report.GarfReport(query_specification=query)
+
     parsed_response = self.parser(query).parse_response(response)
     return report.GarfReport(
       results=parsed_response,

--- a/libs/core/tests/unit/test_report.py
+++ b/libs/core/tests/unit/test_report.py
@@ -144,6 +144,12 @@ class TestGarfReport:
       added_report = empty_report + empty_report
       assert len(added_report) == 0
 
+    def test_add_empty_report_to_non_emptry_report_returns_non_empty_report(
+      self, multi_column_report, empty_report
+    ):
+      added_report = empty_report + multi_column_report + empty_report
+      assert added_report == multi_column_report
+
     def test_add_two_reports(self, multi_column_report):
       added_report = multi_column_report + multi_column_report
       assert len(added_report) == len(multi_column_report.results) * 2

--- a/libs/core/tests/unit/test_report_fetcher.py
+++ b/libs/core/tests/unit/test_report_fetcher.py
@@ -51,6 +51,16 @@ class TestApiReportFetcher:
 
     assert test_report == expected_report
 
+  def test_fetch_returns_empty_report_for_empty_api_response(self):
+    test_api_client = api_clients.FakeApiClient(results=[])
+    fetcher = report_fetcher.ApiReportFetcher(
+      api_client=test_api_client, parser=parsers.DictParser
+    )
+    query = 'SELECT column.name, other_column FROM test'
+    test_report = fetcher.fetch(query)
+
+    assert not test_report
+
   def test_fetch_builtin_query_returns_correct_builtin_report(
     self, test_dict_report_fetcher
   ):


### PR DESCRIPTION
* Add __bool__ method to GarfApiResponse to check whether there is any data
* If API returns no response, return an empty report
* Ensure that when empty and non-empty reports are added only non-empty report is returned