### PR TITLE
[youtube-data-api] fix: handle HttpError when calling API

### DIFF
--- a/libs/community/google/youtube/youtube-data-api/garf_youtube_data_api/__init__.py
+++ b/libs/community/google/youtube/youtube-data-api/garf_youtube_data_api/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Defines simplified imports."""
+"""Interacts with YouTube Data API via garf."""
 
 from __future__ import annotations
 
@@ -24,4 +24,4 @@ __all__ = [
   'YouTubeDataApiReportFetcher',
 ]
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'

--- a/libs/community/google/youtube/youtube-data-api/garf_youtube_data_api/api_clients.py
+++ b/libs/community/google/youtube/youtube-data-api/garf_youtube_data_api/api_clients.py
@@ -19,6 +19,7 @@ import warnings
 
 from garf_core import api_clients, query_editor
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from typing_extensions import override
 
 from garf_youtube_data_api import exceptions
@@ -91,8 +92,11 @@ class YouTubeDataApiClient(api_clients.BaseClient):
   def _list(
     self, service, part: str, next_page_token: str | None = None, **kwargs
   ) -> dict:
-    if next_page_token:
-      return service.list(
-        part=part, pageToken=next_page_token, **kwargs
-      ).execute()
-    return service.list(part=part, **kwargs).execute()
+    try:
+      if next_page_token:
+        return service.list(
+          part=part, pageToken=next_page_token, **kwargs
+        ).execute()
+      return service.list(part=part, **kwargs).execute()
+    except HttpError:
+      return {'items': None}

--- a/libs/community/google/youtube/youtube-data-api/tests/e2e/test_lib.py
+++ b/libs/community/google/youtube/youtube-data-api/tests/e2e/test_lib.py
@@ -22,6 +22,13 @@ api_client = api_clients.YouTubeDataApiClient()
 fetcher = report_fetcher.YouTubeDataApiReportFetcher(api_client=api_client)
 
 
+def test_query_with_non_existing_id_returns_empty_report():
+  query = 'SELECT id, snippet.title AS title FROM videos'
+  test_youtube_id = 'no-existing-video-id'
+  fetched_report = fetcher.fetch(query, id=[test_youtube_id])
+  assert not fetched_report
+
+
 def test_query_with_ids_only():
   query = 'SELECT id, snippet.title AS title FROM videos'
   test_youtube_id = os.getenv('YOUTUBE_ID')


### PR DESCRIPTION
If video or channel not found and cannot be access return empty response.