### PR TITLE
[io] fix: ensure that remote file paths are correctly processed

### DIFF
--- a/libs/io/garf_io/__init__.py
+++ b/libs/io/garf_io/__init__.py
@@ -14,4 +14,4 @@
 
 """Writing GarfReport to anywhere."""
 
-__version__ = '0.0.15'
+__version__ = '0.0.16'

--- a/libs/io/garf_io/writers/csv_writer.py
+++ b/libs/io/garf_io/writers/csv_writer.py
@@ -86,7 +86,7 @@ class CsvWriter(file_writer.FileWriter):
     destination = formatter.format_extension(destination, new_extension='.csv')
     self.create_dir()
     logger.debug('Writing %d rows of data to %s', len(report), destination)
-    output_path = pathlib.Path(self.destination_folder) / destination
+    output_path = os.path.join(self.destination_folder, destination)
     with smart_open.open(
       output_path,
       encoding='utf-8',

--- a/libs/io/garf_io/writers/json_writer.py
+++ b/libs/io/garf_io/writers/json_writer.py
@@ -71,7 +71,7 @@ class JsonWriter(file_writer.FileWriter):
     )
     self.create_dir()
     logger.debug('Writing %d rows of data to %s', len(report), destination)
-    output_path = pathlib.Path(self.destination_folder) / destination
+    output_path = os.path.join(self.destination_folder, destination)
     with smart_open.open(output_path, 'w', encoding='utf-8') as f:
       f.write(report.to_json(output=self.format))
     logger.debug('Writing to %s is completed', output_path)


### PR DESCRIPTION
Switch from pathlib.Path to os.path.join to ensure correct path building.