### PR TITLE
[executors] feat: make init of telemetry optional

### DIFF
--- a/libs/executors/garf_executors/__init__.py
+++ b/libs/executors/garf_executors/__init__.py
@@ -50,4 +50,4 @@ __all__ = [
   'ApiExecutionContext',
 ]
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/libs/executors/garf_executors/entrypoints/cli.py
+++ b/libs/executors/garf_executors/entrypoints/cli.py
@@ -27,7 +27,9 @@ from garf_io import reader
 
 import garf_executors
 from garf_executors import config, exceptions
-from garf_executors.entrypoints import utils
+from garf_executors.entrypoints import tracer, utils
+
+tracer.initialize_tracer()
 
 
 def main():

--- a/libs/executors/garf_executors/entrypoints/tracer.py
+++ b/libs/executors/garf_executors/entrypoints/tracer.py
@@ -34,11 +34,9 @@ def initialize_tracer():
 
   tracer_provider = TracerProvider(resource=resource)
 
-  otlp_processor = BatchSpanProcessor(
-    OTLPSpanExporter(
-      endpoint=os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT'), insecure=True
+  if otel_endpoint := os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT'):
+    otlp_processor = BatchSpanProcessor(
+      OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)
     )
-  )
-  tracer_provider.add_span_processor(otlp_processor)
-
+    tracer_provider.add_span_processor(otlp_processor)
   trace.set_tracer_provider(tracer_provider)


### PR DESCRIPTION
* Emit telemetry data only if there's OTEL_EXPORTER_OTLP_ENDPOINT
* Add tracer initialization into a CLI entrypoint