### PR TITLE
[core] feat: add support for ignoring fields when parsing API response

### DIFF
--- a/docs/usage/queries.md
+++ b/docs/usage/queries.md
@@ -59,6 +59,19 @@ FROM campaign
 
 If you don't specify an alias it will be generated as full column name where "." replaced with "_".
 
+!!!important
+    If you don't want to include a field into a response but a concrete API
+    requires it to be included in request you can ignore it with `_` for a
+    for a column name.
+
+    ```sql
+    SELECT
+      column_1 AS _,
+      column_2
+    FROM resource
+    ```
+
+
 ### Nested Resources
 
 Some fields return structs, and if you want to get a nested attribute scalar value you can use nested resource selectors.
@@ -117,14 +130,22 @@ SELECT
 FROM campaign
 ```
 
-Virtual columns can contain constants (i.e. `1 AS counter` will add new column `counter` filled with `1`) or expressions.
-Expressions can contain field selectors, constants and any arithmetics operations with them.
-For example `metrics.clicks / metrics.impressions AS ctr` will calculate `metrics.clicks / metrics.impressions` for each row of API response and store the results in a new column `ctr`.
-For this the fields `metrics.clicks` and `metrics.impressions` will be fetched implicitly.
-Or for example `campaign.target_cpa.target_cpa_micros / 1000000 AS target_cpa` expression will fetch `campaign.target_cpa.target_cpa_micros` field but return the result of its division by 1000000.
+Virtual columns can contain **constants** (i.e. `1 AS counter` will add new column `counter` filled with `1`) or **expressions**.
 
-The query parser parses a query and remove all columns which are not simple field accessors (i.e. contains anything except field names).
-For constants columns they will be re-added into result after executing the query. For more complex columns with expressions (i.e. some operations with fields) the result will evaluated using the response from API.
+Expressions can contain field selectors, constants and any arithmetics operations with them.
+For example `metrics.clicks / metrics.impressions AS ctr` will calculate
+`metrics.clicks / metrics.impressions` for each row of API response and store the results in a new column `ctr`.
+For this the fields `metrics.clicks` and `metrics.impressions` will be fetched implicitly.
+
+Or for example `campaign.target_cpa.target_cpa_micros / 1000000 AS target_cpa`
+expression will fetch `campaign.target_cpa.target_cpa_micros` field but
+return the result of its division by 1000000.
+
+The query parser parses a query and remove all columns which are not simple
+field accessors (i.e. contains anything except field names).
+For constants columns they will be re-added into result after executing the
+query. For more complex columns with expressions (i.e. some operations with
+fields) the result will evaluated using the response from API.
 
 
 ## Macros
@@ -180,7 +201,6 @@ SELECT
   leaf_account_id
   {% endif %}
 FROM dataset1.table1
-WHERE name LIKE @name
 ```
 
 When this query is executed it's expected to have template `--template.level=...` is supplied to `garf`.

--- a/libs/core/garf_core/__init__.py
+++ b/libs/core/garf_core/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
   'ApiReportFetcher',
 ]
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/libs/core/garf_core/parsers.py
+++ b/libs/core/garf_core/parsers.py
@@ -144,6 +144,9 @@ class BaseParser(abc.ABC):
     fields = self.query_spec.fields
     index = 0
     for column in self.query_spec.column_names:
+      if column == '_':
+        index += 1
+        continue
       if virtual_column := self.query_spec.virtual_columns.get(column):
         result = self.process_virtual_column(row, virtual_column)
       elif customizer := self.query_spec.customizers.get(column):

--- a/libs/core/garf_core/query_editor.py
+++ b/libs/core/garf_core/query_editor.py
@@ -316,6 +316,12 @@ class QuerySpecification(CommonParametersMixin, TemplateProcessorMixin):
     for line in self._extract_query_lines():
       line_elements = query_parser.ExtractedLineElements.from_query_line(line)
       self.query.column_names.append(line_elements.alias)
+      if set(self.query.column_names) == {
+        '_',
+      } and len(self.query.fields) == len(self.query.column_names):
+        raise query_parser.GarfQueryError(
+          'At least one column should be included into a query.'
+        )
     return self
 
   def extract_virtual_columns(self) -> Self:

--- a/libs/core/tests/unit/test_parsers.py
+++ b/libs/core/tests/unit/test_parsers.py
@@ -117,6 +117,24 @@ class TestDictParser:
 
     assert parsed_row == expected_row
 
+  def test_parse_response_skips_omitted_columns(self):
+    test_specification = query_editor.QuerySpecification(
+      'SELECT test_column_1 AS _, test_column_2 FROM test'
+    ).generate()
+
+    test_parser = parsers.DictParser(test_specification)
+    test_response = api_clients.GarfApiResponse(
+      results=[
+        {'test_column_1': '1', 'test_column_2': 2},
+        {'test_column_1': '11', 'test_column_2': 22},
+      ]
+    )
+
+    parsed_row = test_parser.parse_response(test_response)
+    expected_row = [[2], [22]]
+
+    assert parsed_row == expected_row
+
 
 class TestNumericDictParser:
   @pytest.fixture

--- a/libs/core/tests/unit/test_query_editor.py
+++ b/libs/core/tests/unit/test_query_editor.py
@@ -118,6 +118,16 @@ class TestQuerySpecification:
 
     assert test_query_spec.query == expected_query_elements
 
+  def test_generate_raises_error_on_missing_column_names(self):
+    test_query_spec = query_editor.QuerySpecification(
+      text='SELECT column AS _ FROM resource'
+    )
+    with pytest.raises(
+      query_parser.GarfQueryError,
+      match='At least one column should be included into a query.',
+    ):
+      test_query_spec.generate()
+
   def test_generate_returns_builtin_query(self):
     query = 'SELECT test FROM builtin.test'
     test_query_spec = query_editor.QuerySpecification(text=query, title='test')


### PR DESCRIPTION
If getting field is necessary but it's not needed use `_` as a column name to exclude field from GarfReport