### PR TITLE
[core] feat: add 'dict' option to GarfReport.to_dict

### DIFF
--- a/docs/usage/reports.md
+++ b/docs/usage/reports.md
@@ -84,9 +84,16 @@ campaigns_dict = campaigns.to_dict(
 # map campaign_id to campaign_name one-to-many
 campaigns_dict = campaigns.to_dict(
   key_column="campaign_id",
-  value_column="clicks",
   value_column_output="list",
 )
+
+# convert `campaigns` to dictionary
+# where values are another dictionary
+campaigns_dict = campaigns.to_dict(
+  key_column="campaign_id",
+  value_column_output="dict",
+)
+```
 ```
 
 #### Building

--- a/libs/core/garf_core/__init__.py
+++ b/libs/core/garf_core/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
   'ApiReportFetcher',
 ]
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/libs/core/garf_core/report.py
+++ b/libs/core/garf_core/report.py
@@ -136,7 +136,7 @@ class GarfReport:
     self,
     key_column: str,
     value_column: str | None = None,
-    value_column_output: Literal['scalar', 'list'] = 'list',
+    value_column_output: Literal['scalar', 'list', 'dict'] = 'list',
   ) -> dict[str, api_clients.ApiRowElement | list[api_clients.ApiRowElement]]:
     """Converts report to dictionary.
 
@@ -174,7 +174,18 @@ class GarfReport:
       if not value_column:
         value = dict(zip(self.column_names, value))
       if value_column_output == 'list':
+        if not value_column:
+          del value[key_column]
         output[key].append(value)
+      elif value_column_output == 'dict':
+        del value[key_column]
+        if key not in output:
+          output[key] = value
+        else:
+          raise GarfReportError(
+            f'Non unique values found for key_column: {key_column}, '
+            'consider using `value_column_output="list"` instead'
+          )
       else:
         if output.get(key) and output.get(key) != value:
           raise GarfReportError(

--- a/libs/core/tests/unit/test_report.py
+++ b/libs/core/tests/unit/test_report.py
@@ -416,10 +416,44 @@ class TestGarfReport:
       key_column = 'campaign_id'
       output_dict = multi_column_report.to_dict(key_column=key_column)
       assert output_dict == {
-        1: [{'campaign_id': 1, 'ad_group_id': 2}],
-        2: [{'campaign_id': 2, 'ad_group_id': 3}],
-        3: [{'campaign_id': 3, 'ad_group_id': 4}],
+        1: [{'ad_group_id': 2}],
+        2: [{'ad_group_id': 3}],
+        3: [{'ad_group_id': 4}],
       }
+
+      test_report = report.GarfReport(
+        results=[[1, 1], [1, 2], [1, 3]],
+        column_names=['campaign_id', 'ad_group_id'],
+      )
+      key_column = 'campaign_id'
+      output_dict = test_report.to_dict(
+        key_column=key_column, value_column_output='list'
+      )
+      assert output_dict == {
+        1: [{'ad_group_id': 1}, {'ad_group_id': 2}, {'ad_group_id': 3}]
+      }
+
+    def test_multi_column_report_converted_to_dict_with_dict_values(self):
+      test_report = report.GarfReport(
+        results=[[1, 1], [1, 2], [1, 3]],
+        column_names=['campaign_id', 'ad_group_id'],
+      )
+      key_column = 'ad_group_id'
+      output_dict = test_report.to_dict(
+        key_column=key_column, value_column_output='dict'
+      )
+      assert output_dict == {
+        1: {'campaign_id': 1},
+        2: {'campaign_id': 1},
+        3: {'campaign_id': 1},
+      }
+
+      key_column = 'campaign_id'
+      with pytest.raises(
+        report.GarfReportError,
+        match=f'Non unique values found for key_column: {key_column}',
+      ):
+        test_report.to_dict(key_column=key_column, value_column_output='dict')
 
     def test_multi_column_report_converted_to_dict_without_arguments(
       self,


### PR DESCRIPTION
Add support for converting reports to dict with dict values (current implementation was either a scalar or a list)