### PR TITLE
[exporters] docs: fix link for garf-exporter docs

### DIFF
--- a/libs/exporters/README.md
+++ b/libs/exporters/README.md
@@ -53,4 +53,4 @@ Once `garf-exporter` is running you can see exposed metrics at `localhost:8000/m
 
 Explore full documentation on using `garf-exporter`
 
-* [Documentation](https://google.github.io/garf/usage/exporters.md)
+* [Documentation](https://google.github.io/garf/usage/exporters/)


### PR DESCRIPTION
- fixed the garf-exporter documentation link