### PR TITLE
[executors] fix: SQL executor works with any type of query (path, console)

### DIFF
--- a/libs/executors/garf_executors/__init__.py
+++ b/libs/executors/garf_executors/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
   'ApiExecutionContext',
 ]
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/libs/executors/garf_executors/entrypoints/cli.py
+++ b/libs/executors/garf_executors/entrypoints/cli.py
@@ -117,14 +117,17 @@ def main():
       enable_cache=args.enable_cache,
       cache_ttl_seconds=args.cache_ttl_seconds,
     )
-    if args.parallel_queries:
+    if args.parallel_queries and len(args.query) > 1:
       logger.info('Running queries in parallel')
       batch = {query: reader_client.read(query) for query in args.query}
       query_executor.execute_batch(batch, context, args.parallel_threshold)
     else:
-      logger.info('Running queries sequentially')
+      if len(args.query) > 1:
+        logger.info('Running queries sequentially')
       for query in args.query:
-        query_executor.execute(reader_client.read(query), query, context)
+        query_executor.execute(
+          query=reader_client.read(query), title=query, context=context
+        )
   logging.shutdown()
 
 

--- a/libs/executors/garf_executors/sql_executor.py
+++ b/libs/executors/garf_executors/sql_executor.py
@@ -25,6 +25,7 @@ except ImportError as e:
 
 import logging
 import re
+import uuid
 
 import pandas as pd
 from garf_core import query_editor, report
@@ -95,7 +96,7 @@ class SqlAlchemyQueryExecutor(
         conn.connection.executescript(query_text)
         results = report.GarfReport()
       else:
-        temp_table_name = f'temp_{title}'.replace('.', '_')
+        temp_table_name = f'temp_{uuid.uuid4().hex}'
         query_text = f'CREATE TABLE {temp_table_name} AS {query_text}'
         conn.connection.executescript(query_text)
         try:


### PR DESCRIPTION
* Switch to uuid4 for temp table name generation in SQL executor
* Execute queries in parallel only if there's more than one query