### PR TITLE
feat: Add support for multiple writers for one query

### DIFF
--- a/libs/executors/garf_executors/api_executor.py
+++ b/libs/executors/garf_executors/api_executor.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 class ApiExecutionContext(execution_context.ExecutionContext):
   """Common context for executing one or more queries."""
 
-  writer: str = 'console'
+  writer: str | list[str] = 'console'
 
 
 class ApiQueryExecutor(executor.Executor):

--- a/libs/executors/garf_executors/bq_executor.py
+++ b/libs/executors/garf_executors/bq_executor.py
@@ -102,7 +102,7 @@ class BigQueryExecutor(executor.Executor, query_editor.TemplateProcessorMixin):
         results = report.GarfReport.from_pandas(result.to_dataframe())
       else:
         results = report.GarfReport()
-      if (context.writer or context.writers) and results:
+      if context.writer and results:
         writer_clients = context.writer_clients
         if not writer_clients:
           logger.warning('No writers configured, skipping write operation')

--- a/libs/executors/garf_executors/sql_executor.py
+++ b/libs/executors/garf_executors/sql_executor.py
@@ -105,7 +105,7 @@ class SqlAlchemyQueryExecutor(
           )
         finally:
           conn.connection.execute(f'DROP TABLE {temp_table_name}')
-      if (context.writer or context.writers) and results:
+      if context.writer and results:
         writer_clients = context.writer_clients
         if not writer_clients:
           logger.warning('No writers configured, skipping write operation')

--- a/libs/executors/tests/unit/test_api_executor.py
+++ b/libs/executors/tests/unit/test_api_executor.py
@@ -89,11 +89,8 @@ class TestApiQueryExecutor:
   def test_execute_with_multiple_writers_saves_to_both(self, executor, tmp_path, capsys):
     """Test that multiple writers (console and json) both execute."""
     context = api_executor.ApiExecutionContext(
-      writers=['console', 'json'],
-      writers_parameters=[
-        {'page_size': '10'},
-        {'destination_folder': str(tmp_path)},
-      ],
+      writer=['console', 'json'],
+      writer_parameters={'destination_folder': str(tmp_path)},
     )
     executor.execute(
       query=_TEST_QUERY,

--- a/libs/executors/tests/unit/test_execution_context.py
+++ b/libs/executors/tests/unit/test_execution_context.py
@@ -81,20 +81,14 @@ class TestExecutionContext:
     context.save(tmp_config)
     with open(tmp_config, 'r', encoding='utf-8') as f:
       config_data = yaml.safe_load(f)
-    # Due to backward compatibility conversion, writers and writers_parameters
-    # will be added automatically, so we check that original fields are preserved
+    # Check that the data is saved correctly without extra fields
     assert config_data['writer'] == data['writer']
     assert config_data['writer_parameters'] == data['writer_parameters']
-    assert config_data['writers'] == [data['writer']]
-    assert config_data['writers_parameters'] == [data['writer_parameters']]
 
   def test_multiple_writers_creates_multiple_clients(self, tmp_path):
     context = ExecutionContext(
-      writers=['console', 'json'],
-      writers_parameters=[
-        {'page_size': '10'},
-        {'destination_folder': str(tmp_path)},
-      ],
+      writer=['console', 'json'],
+      writer_parameters={'destination_folder': str(tmp_path)},
     )
     writer_clients = context.writer_clients
     assert len(writer_clients) == 2
@@ -103,7 +97,7 @@ class TestExecutionContext:
 
   def test_multiple_writers_without_parameters_creates_empty_dicts(self):
     context = ExecutionContext(
-      writers=['console', 'json'],
+      writer=['console', 'json'],
     )
     writer_clients = context.writer_clients
     assert len(writer_clients) == 2
@@ -121,24 +115,17 @@ class TestExecutionContext:
     assert len(writer_clients) == 1
     assert writer_clients[0].__class__.__name__ == 'JsonWriter'
 
-  def test_writers_parameters_length_mismatch_raises_error(self):
-    with pytest.raises(ValueError, match='writers_parameters length'):
-      ExecutionContext(
-        writers=['console', 'json'],
-        writers_parameters=[{'page_size': '10'}],  # Only one param dict for two writers
-      )
 
   def test_from_file_with_multiple_writers(self, tmp_path):
     tmp_config = tmp_path / 'config.yaml'
     data = {
-      'writers': ['console', 'json'],
-      'writers_parameters': [
-        {'page_size': '10'},
-        {'destination_folder': '/tmp'},
-      ],
+      'writer': ['console', 'json'],
+      'writer_parameters': {
+        'destination_folder': '/tmp',
+      },
     }
     with open(tmp_config, 'w', encoding='utf-8') as f:
       yaml.dump(data, f, encoding='utf-8')
     context = ExecutionContext.from_file(tmp_config)
-    assert context.writers == ['console', 'json']
+    assert context.writer == ['console', 'json']
     assert len(context.writer_clients) == 2


### PR DESCRIPTION
This PR adds support for using multiple writers for a single query.
Now users can pass:
- writers — a list of writer names
- writers_parameters — matching list of parameter dicts

The executor now loops through all writer clients and runs each one.
Single-writer configs still work the same for backward compatibility.

issue - #193 

I also added tests to confirm:
- multiple writers are created
- both writers run during execution
- old single-writer behavior still works
- config loading supports the new fields