### PR TITLE
[executors] fix: init super classes for Bq and SQl executors

### DIFF
--- a/libs/executors/garf_executors/__init__.py
+++ b/libs/executors/garf_executors/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
   'ApiExecutionContext',
 ]
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'


### PR DESCRIPTION
* Provide query title when executor fails to run the query
* Provide INFO logging messages for bq executor