### PR TITLE
fix(core): propagate title of a query to report fetcher

### DIFF
--- a/libs/core/garf/core/__init__.py
+++ b/libs/core/garf/core/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
   'ApiReportFetcher',
 ]
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/libs/core/garf/core/report_fetcher.py
+++ b/libs/core/garf/core/report_fetcher.py
@@ -122,6 +122,7 @@ class ApiReportFetcher:
     self,
     query_specification: str | query_editor.QuerySpecification,
     args: query_editor.GarfQueryParameters | None = None,
+    title: str | None = None,
     **kwargs: str,
   ) -> report.GarfReport:
     """Asynchronously fetches data from API based on query_specification.
@@ -130,12 +131,13 @@ class ApiReportFetcher:
       query_specification: Query text that will be passed to API
         alongside column_names, customizers and virtual columns.
       args: Arguments that need to be passed to the query.
+      title: Optional title of the query.
 
     Returns:
       GarfReport with results of query execution.
     """
     return await asyncio.to_thread(
-      self.fetch, query_specification, args, **kwargs
+      self.fetch, query_specification, args, title, **kwargs
     )
 
   @tracer.start_as_current_span('fetch')
@@ -143,6 +145,7 @@ class ApiReportFetcher:
     self,
     query_specification: str | query_editor.QuerySpecification,
     args: query_editor.GarfQueryParameters | None = None,
+    title: str | None = None,
     **kwargs: str,
   ) -> report.GarfReport:
     """Fetches data from API based on query_specification.
@@ -151,6 +154,7 @@ class ApiReportFetcher:
       query_specification: Query text that will be passed to API
         alongside column_names, customizers and virtual columns.
       args: Arguments that need to be passed to the query.
+      title: Optional title of the query.
 
     Returns:
       GarfReport with results of query execution.
@@ -168,6 +172,8 @@ class ApiReportFetcher:
         args=args,
       )
     query = query_specification.generate()
+    if not query.title:
+      query.title = title
     if query.is_builtin_query:
       span.set_attribute('is_builtin_query', True)
       if not (builtin_report := self.builtin_queries.get(query.title)):

--- a/libs/executors/garf/executors/__init__.py
+++ b/libs/executors/garf/executors/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
   'ApiExecutionContext',
 ]
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'

--- a/libs/executors/garf/executors/api_executor.py
+++ b/libs/executors/garf/executors/api_executor.py
@@ -21,6 +21,7 @@ GarfReport and saving it to local/remote storage.
 from __future__ import annotations
 
 import logging
+import pathlib
 
 from garf.core import report_fetcher
 from garf.executors import (
@@ -110,9 +111,11 @@ class ApiQueryExecutor(executor.Executor):
       span.set_attribute('query.title', title)
       span.set_attribute('query.text', query)
       logger.debug('starting query %s', query)
+      title = pathlib.Path(title).name.split('.')[0]
       results = self.fetcher.fetch(
         query_specification=query,
         args=context.query_parameters,
+        title=title,
         **context.fetcher_parameters,
       )
       writer_clients = context.writer_clients


### PR DESCRIPTION
When query is provide as a text (and not QueryElements object) the information on it's title is lost in executor (despite being provided).