### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/publish_garf_bid_manager.yaml
+++ b/.github/workflows/publish_garf_bid_manager.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_garf_exporter.yaml
+++ b/.github/workflows/publish_garf_exporter.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_garf_google_ads.yaml
+++ b/.github/workflows/publish_garf_google_ads.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_garf_google_analytics.yaml
+++ b/.github/workflows/publish_garf_google_analytics.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_garf_knowledge_graph.yaml
+++ b/.github/workflows/publish_garf_knowledge_graph.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_garf_merchant_center.yaml
+++ b/.github/workflows/publish_garf_merchant_center.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_garf_youtube.yaml
+++ b/.github/workflows/publish_garf_youtube.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_pypi_core.yaml
+++ b/.github/workflows/publish_pypi_core.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_pypi_executors.yaml
+++ b/.github/workflows/publish_pypi_executors.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/publish_pypi_io.yaml
+++ b/.github/workflows/publish_pypi_io.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install uv

--- a/.github/workflows/push-garf-exporter-to-github-packages.yaml
+++ b/.github/workflows/push-garf-exporter-to-github-packages.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/push-garf-to-github-packages.yaml
+++ b/.github/workflows/push-garf-to-github-packages.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         library: [core, io, executors]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup uv
@@ -55,9 +55,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup uv

--- a/.github/workflows/test_garf_bid_manager.yaml
+++ b/.github/workflows/test_garf_bid_manager.yaml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Setup uv

--- a/.github/workflows/test_garf_exporter.yaml
+++ b/.github/workflows/test_garf_exporter.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup uv

--- a/.github/workflows/test_garf_google_ads.yaml
+++ b/.github/workflows/test_garf_google_ads.yaml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Setup uv

--- a/.github/workflows/test_garf_youtube.yaml
+++ b/.github/workflows/test_garf_youtube.yaml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Setup uv


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | publish_garf_bid_manager.yaml, publish_garf_exporter.yaml, publish_garf_google_ads.yaml, publish_garf_google_analytics.yaml, publish_garf_knowledge_graph.yaml, publish_garf_merchant_center.yaml, publish_garf_youtube.yaml, publish_pypi_core.yaml, publish_pypi_executors.yaml, publish_pypi_io.yaml, push-garf-exporter-to-github-packages.yaml, push-garf-to-github-packages.yaml, test.yaml, test_garf_bid_manager.yaml, test_garf_exporter.yaml, test_garf_google_ads.yaml, test_garf_youtube.yaml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | test.yaml, test_garf_bid_manager.yaml, test_garf_exporter.yaml, test_garf_google_ads.yaml, test_garf_youtube.yaml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
