### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/push-garf-exporter-to-github-packages.yaml
+++ b/.github/workflows/push-garf-exporter-to-github-packages.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -31,12 +31,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
         with:
           context: libs/exporters/.
           push: true

--- a/.github/workflows/push-garf-to-github-packages.yaml
+++ b/.github/workflows/push-garf-to-github-packages.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -31,12 +31,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
         with:
           context: libs/executors/.
           push: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           coverage run -m pytest libs/${{ matrix.library }}/tests/unit
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test-e2e:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `codecov/codecov-action` | [`v3`](https://github.com/codecov/codecov-action/releases/tag/v3) | [`v5`](https://github.com/codecov/codecov-action/releases/tag/v5) | [Release](https://github.com/codecov/codecov-action/releases/tag/v5) | test.yaml |
| `docker/build-push-action` | [`ad44023`](https://github.com/docker/build-push-action/commit/ad44023a93711e3deb337508980b4b5e9bcdc5dc) | [`2634353`](https://github.com/docker/build-push-action/commit/263435318d21b8e681c14492fe198d362a7d2c83) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | push-garf-exporter-to-github-packages.yaml, push-garf-to-github-packages.yaml |
| `docker/login-action` | [`f054a8b`](https://github.com/docker/login-action/commit/f054a8b539a109f9f41c372932f1ae047eff08c9) | [`5e57cd1`](https://github.com/docker/login-action/commit/5e57cd118135c172c3672efd75eb46360885c0ef) | [Release](https://github.com/docker/login-action/releases/tag/v3) | push-garf-exporter-to-github-packages.yaml, push-garf-to-github-packages.yaml |
| `docker/metadata-action` | [`98669ae`](https://github.com/docker/metadata-action/commit/98669ae865ea3cffbcbaa878cf57c20bbf1c6c38) | [`c299e40`](https://github.com/docker/metadata-action/commit/c299e40c65443455700f0fdfc63efafe5b349051) | [Release](https://github.com/docker/metadata-action/releases/tag/v5) | push-garf-exporter-to-github-packages.yaml, push-garf-to-github-packages.yaml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
