### PR TITLE
feat(executors): improve writing in bq/sql executors

### DIFF
--- a/libs/executors/garf/executors/setup.py
+++ b/libs/executors/garf/executors/setup.py
@@ -54,7 +54,8 @@ def setup_executor(
     sql_executor = importlib.import_module('garf.executors.sql_executor')
     query_executor = (
       sql_executor.SqlAlchemyQueryExecutor.from_connection_string(
-        fetcher_parameters.get('connection_string')
+        connection_string=fetcher_parameters.get('connection_string'),
+        writers=writer_clients,
       )
     )
   else:

--- a/libs/executors/tests/unit/test_bq_executor.py
+++ b/libs/executors/tests/unit/test_bq_executor.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 
-from __future__ import annotations
-
-from garf.executors import bq_executor
+import pytest
+from garf.core import report
+from garf.executors import bq_executor, execution_context
+from garf.io import writer
 
 
 def test_extract_datasets():
@@ -33,3 +35,81 @@ def test_extract_datasets():
   ]
   datasets = bq_executor.extract_datasets(macros)
   assert datasets == expected
+
+
+class TestBigQueryExecutor:
+  @pytest.fixture
+  def executor(self):
+    return bq_executor.BigQueryExecutor(project='test')
+
+  def test_init_raises_error_on_missing_project(self):
+    with pytest.raises(
+      bq_executor.BigQueryExecutorError, match='project is required'
+    ):
+      bq_executor.BigQueryExecutor(project=None)
+
+  def test_init_deprecation_warning(self):
+    with pytest.warns(
+      DeprecationWarning,
+      match=(
+        "'project_id' parameter is deprecated. Please use 'project' instead."
+      ),
+    ):
+      bq_executor.BigQueryExecutor(project_id='test-project')
+
+  def test_execute_returns_data_to_caller(self, executor, mocker):
+    query = 'SELECT 1 AS one;'
+    expected_result = report.GarfReport(results=[[1]], column_names=['one'])
+    mocker.patch(
+      'garf.executors.bq_executor.BigQueryExecutor._query',
+      return_value=expected_result,
+    )
+    result = executor.execute(title='test', query=query)
+    assert result == expected_result
+
+  def test_execute_writers_data_via_executor_writer(self, mocker, tmp_path):
+    writers = writer.setup_writers(
+      writers=['json'], writer_parameters={'destination_folder': tmp_path}
+    )
+    executor = bq_executor.BigQueryExecutor(
+      project='test',
+      writers=writers,
+    )
+    expected_result = report.GarfReport(results=[[1]], column_names=['one'])
+    mocker.patch(
+      'garf.executors.bq_executor.BigQueryExecutor._query',
+      return_value=expected_result,
+    )
+    query = 'SELECT 1 AS one;'
+    result = executor.execute(
+      title='test',
+      query=query,
+    )
+    output_path = str(tmp_path / 'test.json')
+    assert result == f'[JSON] - at {output_path}'
+    with open(output_path, 'r', encoding='utf-8') as f:
+      data = json.load(f)
+    assert data == [{'one': 1}]
+
+  def test_execute_writers_data_via_context_writer(self, mocker, tmp_path):
+    executor = bq_executor.BigQueryExecutor(
+      project='test',
+    )
+    expected_result = report.GarfReport(results=[[1]], column_names=['one'])
+    mocker.patch(
+      'garf.executors.bq_executor.BigQueryExecutor._query',
+      return_value=expected_result,
+    )
+    query = 'SELECT 1 AS one;'
+    result = executor.execute(
+      title='test',
+      query=query,
+      context=execution_context.ExecutionContext(
+        writer='json', writer_parameters={'destination_folder': str(tmp_path)}
+      ),
+    )
+    output_path = str(tmp_path / 'test.json')
+    assert result == f'[JSON] - at {output_path}'
+    with open(output_path, 'r', encoding='utf-8') as f:
+      data = json.load(f)
+    assert data == [{'one': 1}]


### PR DESCRIPTION
* check for writers AND context when performing write operation
* bq_executor: switch to project parameter in init, deprecate project_id
* bq_executor: extract interaction with BQ API into a dedicated function for easier testing
* add tests to check that write operation supported both from init and context