### PR TITLE
fix(core): separate commend and traling selicolon removal into two methods

### DIFF
--- a/libs/core/garf/core/__init__.py
+++ b/libs/core/garf/core/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
   'ApiReportFetcher',
 ]
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/libs/core/garf/core/query_editor.py
+++ b/libs/core/garf/core/query_editor.py
@@ -218,7 +218,8 @@ class QuerySpecification(CommonParametersMixin):
   def generate(self) -> BaseQueryElements:
     self.remove_comments().expand().extract_resource_name()
     (
-      self.remove_trailing_comma()
+      self.remove_final_semicolon()
+      .remove_trailing_comma()
       .extract_fields()
       .extract_filters()
       .extract_sorts()
@@ -243,6 +244,10 @@ class QuerySpecification(CommonParametersMixin):
         self.query.text = query_text.format(**self.macros).strip()
     except KeyError as e:
       raise GarfMacroError(f'No value provided for macro {str(e)}.') from e
+    return self
+
+  def remove_final_semicolon(self) -> Self:
+    self.query.text = re.sub(';$', '', self.query.text)
     return self
 
   def remove_comments(self) -> Self:
@@ -270,9 +275,7 @@ class QuerySpecification(CommonParametersMixin):
         continue
       if re.match('^(#|--|//) ', line) or line in ('--', '#', '//'):
         continue
-      cleaned_query_line = re.sub(
-        ';$', '', re.sub('(--|//) .*$', '', line).strip()
-      )
+      cleaned_query_line = re.sub('(--|//) .*$', '', line).strip()
       result.append(cleaned_query_line)
     self.query.text = ' '.join(result)
     return self

--- a/libs/executors/tests/unit/test_sql_executor.py
+++ b/libs/executors/tests/unit/test_sql_executor.py
@@ -41,6 +41,22 @@ class TestSqlAlchemyQueryExecutor:
       for row in result:
         assert row.one == 1
 
+  def test_execute_works_with_multiple_tables(self, executor, engine):
+    query = """
+    CREATE TABLE test1 AS SELECT 1 AS one;
+    CREATE TABLE test2 AS SELECT 2 AS one;
+    """
+    executor.execute(title='test', query=query)
+
+    with engine.connect() as connection:
+      result = connection.execute(sqlalchemy.text('select one from test1'))
+      for row in result:
+        assert row.one == 1
+
+      result = connection.execute(sqlalchemy.text('select one from test2'))
+      for row in result:
+        assert row.one == 2
+
   def test_execute_returns_data_to_caller(self, executor):
     query = 'SELECT 1 AS one;'
     expected_result = report.GarfReport(results=[[1]], column_names=['one'])


### PR DESCRIPTION
Since bq/sql executors are using functionality of QuerySpecification it does not make sence to remove semicolons for them