### PR TITLE
fix(executors): add project_id to bq_executor and bump dependencies

### DIFF
--- a/libs/executors/garf/executors/__init__.py
+++ b/libs/executors/garf/executors/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
   'ApiExecutionContext',
 ]
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/libs/executors/garf/executors/bq_executor.py
+++ b/libs/executors/garf/executors/bq_executor.py
@@ -91,6 +91,15 @@ class BigQueryExecutor(executor.Executor):
         self._client = bigquery.Client(self.project)
     return self._client
 
+  @property
+  def project_id(self) -> str:
+    warnings.warn(
+      "'project_id' property is deprecated. Please use 'project' instead.",
+      DeprecationWarning,
+      stacklevel=2,
+    )
+    return self.project
+
   @tracer.start_as_current_span('bq.execute')
   def execute(
     self,

--- a/libs/executors/pyproject.toml
+++ b/libs/executors/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "garf-executors"
 dependencies = [
-  "garf-core>=1.0.0",
+  "garf-core>=1.1.1",
   "garf-io>=1.0.0",
   "pyyaml",
   "pydantic",


### PR DESCRIPTION
* legacy systems might use BigQueryExecutor.project_id property
* ensure that multistatements are supported (pin garf-core 1.1.1+)