### PR TITLE
Update api_clients.py

### DIFF
--- a/libs/community/google/youtube/garf/community/google/youtube/api_clients.py
+++ b/libs/community/google/youtube/garf/community/google/youtube/api_clients.py
@@ -228,11 +228,23 @@ class YouTubeDataApiClient(api_clients.BaseClient):
                   'comp': comparator.value,
                 },
               )
-            else:
-              include_row = eval(
-                f'{res} {comparator.operator} {comparator.value}', globals()
-              )
-            if not include_row:
+          else:
+              import operator as _op_module
+              _SAFE_OPS = {
+                '==': _op_module.eq,
+                '!=': _op_module.ne,
+                '>':  _op_module.gt,
+                '>=': _op_module.ge,
+                '<':  _op_module.lt,
+                '<=': _op_module.le,
+              }
+              _op_fn = _SAFE_OPS.get(comparator.operator)
+              if _op_fn is None:
+                raise YouTubeDataApiClientError(
+                  f'Unsupported filter operator: {comparator.operator!r}'
+                )
+                include_row = _op_fn(res, comparator.value)
+          if not include_row:
               break
           if include_row:
             filtered_results.append(row)


### PR DESCRIPTION
fix(youtube): replace eval() with operator lookup in filter evaluation

Filter comparisons in YouTubeDataApiClient.get_response() were evaluated using eval() with globals(), allowing arbitrary code execution via user-supplied WHERE clause values or crafted API response data.

Replace with a safe operator lookup table (operator.eq, operator.gt, etc.) that handles only the supported comparison operators explicitly.