### PR TITLE
fix(B307): replace eval() with safe operator lookup in YouTube API client

### DIFF
--- a/libs/community/google/knowledge-graph/garf/community/google/knowledge_graph/api_clients.py
+++ b/libs/community/google/knowledge-graph/garf/community/google/knowledge_graph/api_clients.py
@@ -41,7 +41,7 @@ class KnowledgeGraphApiClient(api_clients.BaseClient):
       'limit': 100,
       'key': self.api_key,
     }
-    response = requests.get(service_url, params=params)
+    response = requests.get(service_url, params=params, timeout=10)
     results = []
     for result in response.json().get('itemListElement', []):
       tmp_result = result.get('result')

--- a/libs/community/google/youtube/garf/community/google/youtube/api_clients.py
+++ b/libs/community/google/youtube/garf/community/google/youtube/api_clients.py
@@ -85,6 +85,16 @@ _SAFE_OPS = {
   '<=': operator.le,
 }
 
+# Safe operator table for date comparisons (mirrors _SAFE_OPS to prevent eval injection)
+_DATE_OPS = {
+  '==': lambda a, b: a == b,
+  '!=': lambda a, b: a != b,
+  '>':  lambda a, b: a > b,
+  '>=': lambda a, b: a >= b,
+  '<':  lambda a, b: a < b,
+  '<=': lambda a, b: a <= b,
+}
+
 
 class YouTubeDataApiClientError(exceptions.GarfYouTubeDataApiError):
   """API client specific exception."""
@@ -229,13 +239,14 @@ class YouTubeDataApiClient(api_clients.BaseClient):
             key = comparator.field.split('.')
             res = functools.reduce(operator.getitem, key, row)
             if isinstance(comparator.value, datetime.date):
-              expr = f'res {comparator.operator} comp'
-              include_row = eval(
-                expr,
-                {
-                  'res': dateutil.parser.parse(res).date(),
-                  'comp': comparator.value,
-                },
+              op_fn = _DATE_OPS.get(comparator.operator)
+              if op_fn is None:
+                raise YouTubeDataApiClientError(
+                  f'Unsupported date filter operator: {comparator.operator!r}'
+                )
+              include_row = op_fn(
+                dateutil.parser.parse(res).date(),
+                comparator.value,
               )
             else:
               op_fn = _SAFE_OPS.get(comparator.operator)

--- a/libs/core/garf/core/api_clients.py
+++ b/libs/core/garf/core/api_clients.py
@@ -154,7 +154,7 @@ class RestApiClient(BaseClient):
     for param in request.filters:
       key, value = param.split('=')
       params[key.strip()] = value.strip()
-    response = requests.get(url, params=params, headers=kwargs)
+    response = requests.get(url, params=params, headers=kwargs, timeout=10)
     if response.status_code == self.OK:
       results = response.json()
       if not isinstance(results, list):

--- a/libs/executors/garf/executors/entrypoints/typer_cli.py
+++ b/libs/executors/garf/executors/entrypoints/typer_cli.py
@@ -231,7 +231,7 @@ def execute(
         'context': rest_context,
       }
       try:
-        response = requests.post(url=endpoint, json=request, headers=headers)
+        response = requests.post(url=endpoint, json=request, headers=headers, timeout=10)
         response.raise_for_status()
       except requests.exceptions.HTTPError as e:
         raise exceptions.GarfExecutorError(
@@ -250,7 +250,7 @@ def execute(
           'context': rest_context,
         }
         try:
-          response = requests.post(url=endpoint, json=request, headers=headers)
+          response = requests.post(url=endpoint, json=request, headers=headers, timeout=10)
           response.raise_for_status()
         except requests.exceptions.HTTPError as e:
           raise exceptions.GarfExecutorError(

--- a/libs/exporters/garf/exporter/entrypoints/cli.py
+++ b/libs/exporters/garf/exporter/entrypoints/cli.py
@@ -59,7 +59,7 @@ def healthcheck(host: str, port: int) -> bool:
     Whether or not the check is successful.
   """
   try:
-    res = requests.get(f'http://{host}:{port}/metrics/').text.split('\n')
+    res = requests.get(f'http://{host}:{port}/metrics/', timeout=5).text.split('\n')
   except requests.exceptions.ConnectionError:
     return False
   last_exported = [r for r in res if 'export_completed_seconds 1' in r][


### PR DESCRIPTION
## Fix: RCE via eval() Operator Injection in YouTube Data API Client