### PR TITLE
feat(prometheus): add option for specifying start / end date as a date object

### DIFF
--- a/libs/community/prometheus/examples/up_range.sql
+++ b/libs/community/prometheus/examples/up_range.sql
@@ -6,6 +6,6 @@ SELECT
 FROM query_range
 WHERE
   query = up
-  AND start=2026-06-03T00:00:30.781Z
-  AND end=2026-06-03T20:11:00.781Z
-  AND step = 15s
+  AND start=2026-06-02
+  AND end=2026-06-03
+  AND step = 1h

--- a/libs/community/prometheus/garf/community/prometheus/api_clients.py
+++ b/libs/community/prometheus/garf/community/prometheus/api_clients.py
@@ -32,16 +32,8 @@ class PrometheusApiClient(api_clients.RestApiClient):
     **kwargs: str,
   ) -> api_clients.GarfApiResponse:
     url = f'{self.endpoint}/api/v1/{request.resource_name}'
-    params = {}
-    for field in request.fields:
-      if field == 'timestamp':
-        continue
-      params['query'] = field
-    for element in request.filters:
-      key, value = element.split(' = ')
-      params[key.strip()] = value.strip().replace(' ', '')
     headers = {k: v for k, v in kwargs.items() if not isinstance(v, bool)}
-    response = requests.get(url, params=params, headers=headers)
+    response = requests.get(url, params=request.filters, headers=headers)
     if response.status_code == self.OK:
       results = response.json()
       if request.resource_name == 'query_range':

--- a/libs/community/prometheus/garf/community/prometheus/query_editor.py
+++ b/libs/community/prometheus/garf/community/prometheus/query_editor.py
@@ -12,8 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+"""Formats Garf Prometheus query for simplified API requests."""
+
+import re
+from typing import override
+
+import dateutil
 from garf.core import query_editor
 
 
 class PrometheusApiQuery(query_editor.QuerySpecification):
   """Query to Prometheus API."""
+
+  @override
+  def generate(self):
+    query = super().generate()
+    updated_filters = {}
+    for filter_statement in query.filters:
+      key, value = filter_statement.split('=')
+      if re.match('^(start|end).*$', key):
+        value = value.strip().replace(' ', '')
+        formatted_datetime = dateutil.parser.parse(value).strftime(
+          '%Y-%m-%dT%H:%M:%S.000Z'
+        )
+        updated_filters[key.strip()] = formatted_datetime
+      else:
+        updated_filters[key.strip()] = value.strip()
+    query.filters = updated_filters
+    return query


### PR DESCRIPTION
* instead of providing example datetime users can provide date
* override `generate` method in PrometheusApiQuery that converts dates and keeps filters as a dict