### PR TITLE
feat: add support for multiple parameters with the same key in garf cli

### DIFF
--- a/docs/usage/queries.md
+++ b/docs/usage/queries.md
@@ -207,10 +207,10 @@ SELECT
 FROM asset_performance
 ```
 
-When this query is executed it's expected to have template `--template.cohort_days=0,1,3,7` is supplied to `garf`.
+When this query is executed it's expected to have template `--template.cohort_days=0 --template.cohort_days=1` is supplied to `garf`.
 
-Please note that all values passed through CLI arguments are strings. But there's a special case - a value containing "," - it's converted to an array.
-It will create 4 columns (named `installs_0_day`, `installs_1_day`, etc).
+Please note that all values passed through CLI arguments are strings.
+It will create 2 columns (named `installs_0_day`, `installs_1_day`).
 
 Learn more about statements [here](https://jinja.palletsprojects.com/en/stable/templates/#list-of-control-structures).
 

--- a/libs/core/garf/core/query_editor.py
+++ b/libs/core/garf/core/query_editor.py
@@ -45,7 +45,9 @@ class GarfQueryParameters(pydantic.BaseModel):
   @property
   def hash(self) -> str:
     hash_fields = self.model_dump(exclude_none=True)
-    return hashlib.md5(json.dumps(hash_fields).encode('utf-8'), usedforsecurity=False).hexdigest()
+    return hashlib.md5(
+      json.dumps(hash_fields).encode('utf-8'), usedforsecurity=False
+    ).hexdigest()
 
   def __eq__(self, other) -> bool:
     return (self.macro, self.template) == (other.macro, other.template)
@@ -121,7 +123,9 @@ class BaseQueryElements(pydantic.BaseModel):
   @property
   def hash(self) -> str:
     hash_fields = self.model_dump(exclude_none=True, exclude={'title', 'text'})
-    return hashlib.md5(json.dumps(hash_fields).encode('utf-8'), usedforsecurity=False).hexdigest()
+    return hashlib.md5(
+      json.dumps(hash_fields).encode('utf-8'), usedforsecurity=False
+    ).hexdigest()
 
 
 class CommonParametersMixin:
@@ -244,12 +248,7 @@ class QuerySpecification(CommonParametersMixin):
     else:
       for key, value in template_params.items():
         if value:
-          if isinstance(value, list):
-            template_params[key] = value
-          elif len(splitted_param := str(value).split(',')) > 1:
-            template_params[key] = splitted_param
-          else:
-            template_params[key] = value
+          template_params[key] = value
         else:
           template_params[key] = ''
       rendered_query = query.render(template_params)

--- a/libs/core/garf/core/version.py
+++ b/libs/core/garf/core/version.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '1.2.3'
+__version__ = '1.2.4'

--- a/libs/core/tests/unit/test_query_editor.py
+++ b/libs/core/tests/unit/test_query_editor.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 
 import pytest
 from dateutil.relativedelta import relativedelta

--- a/libs/executors/garf/executors/entrypoints/utils.py
+++ b/libs/executors/garf/executors/entrypoints/utils.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import enum
 import logging
 import sys
-from collections.abc import Sequence
+from collections.abc import MutableSequence, Sequence
 from typing import Any
 
 from rich import logging as rich_logging
@@ -26,21 +26,22 @@ from rich import logging as rich_logging
 
 class ParamsParser:
   def __init__(self, identifiers: Sequence[str] | None = None) -> None:
-    self.identifiers = identifiers or []
+    self.identifiers = set(identifiers) if identifiers else set()
 
   def parse(self, params: Sequence) -> dict[str, dict | None]:
-    return {
-      identifier: self._parse_params(identifier, params)
-      for identifier in self.identifiers
-    }
+    results = {}
+    for identifier in self.identifiers:
+      result = self._parse_params(identifier, params)
+      results[identifier] = result
+    return results
 
   def parse_all(self, params: Sequence) -> dict[str, dict | None]:
-    identifiers = []
+    identifiers = set()
     for param in params:
       identifier, *value = param.split('.', maxsplit=1)
       if value:
-        identifiers.append(identifier.replace('--', ''))
-    self.identifiers.extend(identifiers)
+        identifiers.add(identifier.replace('--', ''))
+    self.identifiers |= identifiers
     return self.parse(params)
 
   def _parse_params(self, identifier: str, params: Sequence[Any]) -> dict:
@@ -50,7 +51,16 @@ class ParamsParser:
       for param in raw_params:
         param_pair = self._identify_param_pair(identifier, param)
         if param_pair:
-          parsed_params.update(param_pair)
+          if key := (param_pair.keys() & parsed_params.keys()):
+            key = key.pop()
+            previous_value = parsed_params.get(key)
+            if isinstance(previous_value, MutableSequence):
+              joined_pair = {key: [*previous_value, param_pair.get(key)]}
+            else:
+              joined_pair = {key: [previous_value, param_pair.get(key)]}
+            parsed_params.update(joined_pair)
+          else:
+            parsed_params.update(param_pair)
     return parsed_params
 
   def _identify_param_pair(

--- a/libs/executors/garf/executors/version.py
+++ b/libs/executors/garf/executors/version.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from garf.executors import exceptions
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 
 def validate_version(version: str | None = None):

--- a/libs/executors/tests/unit/entrypoints/test_utils.py
+++ b/libs/executors/tests/unit/entrypoints/test_utils.py
@@ -99,6 +99,20 @@ class TestParamsParser:
       },
     }
 
+  @pytest.mark.parametrize(
+    'parameters',
+    [
+      (1, 2),
+      (1, 2, 3),
+    ],
+  )
+  def test_parse_all_handlers_duplicated_identifiers_as_list(self, parameters):
+    param_parser = utils.ParamsParser()
+    params = [f'--template.key={p}' for p in parameters]
+    parsed_params = param_parser.parse_all(params)
+    expected_parameters = {'template': {'key': [str(p) for p in parameters]}}
+    assert parsed_params == expected_parameters
+
 
 @pytest.mark.parametrize(
   'logger_type',


### PR DESCRIPTION
* Remove special treatment of treatment of comma separated values when expanding template
* Bundle CLI parameters with the same key into list (instead of overwriting them with the last one)
* Update queries.md documentation