### PR TITLE
fix(executors): ensure that writer is treated as a list

### DIFF
--- a/libs/executors/garf/executors/execution_context.py
+++ b/libs/executors/garf/executors/execution_context.py
@@ -54,6 +54,8 @@ class ExecutionContext(pydantic.BaseModel):
   def model_post_init(self, __context__) -> None:
     if self.fetcher_parameters is None:
       self.fetcher_parameters = {}
+    if isinstance(self.writer, str):
+      self.writer = [self.writer]
     if self.writer_parameters is None:
       self.writer_parameters = {}
     if not self.query_parameters:

--- a/libs/executors/garf/executors/workflows/workflow.py
+++ b/libs/executors/garf/executors/workflows/workflow.py
@@ -233,8 +233,9 @@ class Workflow(pydantic.BaseModel):
       if context:
         if fetcher_parameters := context.get(step.fetcher):
           custom_parameters['fetcher_parameters'] = fetcher_parameters
-        if writer_parameters := context.get(step.writer):
-          custom_parameters['writer_parameters'] = writer_parameters
+        for writer in step.writer:
+          if writer_parameters := context.get(writer):
+            custom_parameters['writer_parameters'].update(writer_parameters)
 
       if source_config_parameters := config_parameters.get(step.fetcher):
         res = utils.merge_dicts(

--- a/libs/executors/tests/unit/test_config.py
+++ b/libs/executors/tests/unit/test_config.py
@@ -79,6 +79,7 @@ class TestConfig:
     config.save(tmp_config)
     with open(tmp_config, 'r', encoding='utf-8') as f:
       config_data = yaml.safe_load(f)
+    data['sources']['api']['writer'] = [data['sources']['api']['writer']]
     assert config_data == data
 
   def test_expand(self):

--- a/libs/executors/tests/unit/test_execution_context.py
+++ b/libs/executors/tests/unit/test_execution_context.py
@@ -81,8 +81,7 @@ class TestExecutionContext:
     context.save(tmp_config)
     with open(tmp_config, 'r', encoding='utf-8') as f:
       config_data = yaml.safe_load(f)
-    # Check that the data is saved correctly without extra fields
-    assert config_data['writer'] == data['writer']
+    assert config_data['writer'] == [data['writer']]
     assert config_data['writer_parameters'] == data['writer_parameters']
 
   def test_multiple_writers_creates_multiple_clients(self, tmp_path):

--- a/libs/executors/tests/unit/workflows/test_workflow.py
+++ b/libs/executors/tests/unit/workflows/test_workflow.py
@@ -86,7 +86,9 @@ class TestWorkflow:
     workflow.save(tmp_workflow)
     with open(tmp_workflow, 'r', encoding='utf-8') as f:
       workflow_data = yaml.safe_load(f)
-    assert workflow_data == self.data
+    expected_data = self.data.copy()
+    expected_data['steps'][0]['writer'] = [expected_data['steps'][0]['writer']]
+    assert workflow_data == expected_data
 
   def test_init_with_context(self):
     new_start_date = '2026-01-01'


### PR DESCRIPTION
Implement change into ExecutionContext - single writer is treated a list for consistency