### PR TITLE
feat(executors): use all request parameters in gRPC ExecuteWorkflow method

### DIFF
--- a/libs/executors/garf/executors/entrypoints/grpc_server.py
+++ b/libs/executors/garf/executors/entrypoints/grpc_server.py
@@ -159,7 +159,11 @@ class GarfService(garf_pb2_grpc.GarfService):
 
   def ExecuteWorkflow(self, request, context):
     execution_workflow = workflow.Workflow(
-      **MessageToDict(request.workflow, preserving_proto_field_name=True)
+      **MessageToDict(request.workflow, preserving_proto_field_name=True),
+      context=MessageToDict(request.context, preserving_proto_field_name=True),
+      execution_config=MessageToDict(
+        request.config, preserving_proto_field_name=True
+      ),
     )
     telemetry.workflow_requested.add(
       1, attributes=execution_workflow.attributes
@@ -167,7 +171,13 @@ class GarfService(garf_pb2_grpc.GarfService):
     runner = workflow_runner.WorkflowRunner(
       execution_workflow=execution_workflow
     )
-    results = runner.run()
+    results = runner.run(
+      selected_aliases=request.selected_aliases,
+      skipped_aliases=request.skipped_aliases,
+      simulate=request.simulate,
+      enable_cache=request.cache_options.enable_cache,
+      cache_ttl_seconds=request.cache_options.cache_ttl_seconds,
+    )
     return garf_pb2.ExecuteWorkflowResponse(results=results)
 
   def GetVersion(self, request, context):
@@ -231,7 +241,7 @@ if __name__ == '__main__':
     reflection.SERVICE_NAME,
   )
   reflection.enable_server_reflection(SERVICE_NAMES, server)
-  server.add_insecure_port(f'[::]:{args.port}')
+  server.add_insecure_port(f'127.0.0.1:{args.port}')
   server.start()
   logging.info('Garf service started, listening on port %d', args.port)
   server.wait_for_termination()

--- a/libs/executors/garf/executors/workflows/workflow.py
+++ b/libs/executors/garf/executors/workflows/workflow.py
@@ -238,7 +238,7 @@ class Workflow(pydantic.BaseModel):
 
   steps: list[ExecutionStep | ParallelStep]
   context: dict[str, dict[str, Any]] | None = None
-  execution_config: config.Config | None = None
+  execution_config: config.Config | dict[str, Any] | None = None
   prefix: str | pathlib.Path | None = pydantic.Field(
     default=None, excluded=True
   )

--- a/libs/executors/garf/executors/workflows/workflow_runner.py
+++ b/libs/executors/garf/executors/workflows/workflow_runner.py
@@ -177,9 +177,24 @@ class WorkflowRunner:
         'workflow.fetchers': self.workflow.fetchers,
       }
     )
+    if self.workflow.execution_config:
+      span.set_attributes({'workflow.config': True})
+    if self.workflow.context:
+      span.set_attributes({'workflow.context': True})
+    if skipped_aliases := skipped_aliases or []:
+      span.set_attributes({'workflow.skipped_aliases': skipped_aliases})
+    if selected_aliases := selected_aliases or []:
+      span.set_attributes({'workflow.selected_aliases': selected_aliases})
+    if simulate:
+      span.set_attributes({'workflow.simulate': simulate})
+    if enable_cache:
+      span.set_attributes(
+        {
+          'workflow.enable_cache': enable_cache,
+          'workflow.cache_ttl_seconds': cache_ttl_seconds,
+        }
+      )
     self.workflow.compile()
-    skipped_aliases = skipped_aliases or []
-    selected_aliases = selected_aliases or []
     execution_results = collections.OrderedDict()
     logger.info('Starting Garf Workflow...')
     for i, step in enumerate(self.workflow.steps, 1):


### PR DESCRIPTION


* Use context, config, similate, cache, skipped and selected aliases
* Include extra Otel info for worklow span attributes when running the workflow